### PR TITLE
Make google-protobuf installable via git source in Gemfile

### DIFF
--- a/ruby/BUILD.bazel
+++ b/ruby/BUILD.bazel
@@ -172,7 +172,7 @@ genrule(
         set -eux
         mkdir tmp
         for src in $(SRCS); do
-            cp --parents -L "$$src" tmp
+            mkdir -p "tmp/$$(dirname $$src)" && cp -L "$$src" "tmp/$$src"
         done
         mkdir -p "tmp/ruby/ext/google/protobuf_c/third_party/utf8_range"
         for utf in $(execpaths //third_party/utf8_range:utf8_range_srcs) $(execpath //third_party/utf8_range:LICENSE); do
@@ -210,7 +210,7 @@ genrule(
         set -eux
         mkdir tmp
         for src in $(SRCS); do
-            cp --parents -L "$$src" "tmp"
+            mkdir -p "tmp/$$(dirname $$src)" && cp -L "$$src" "tmp/$$src"
         done
         mkdir -p "tmp/ruby/ext/google/protobuf_c/third_party/utf8_range"
         for utf in $(execpaths //third_party/utf8_range:utf8_range_srcs) $(execpath //third_party/utf8_range:LICENSE); do

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -47,7 +47,9 @@ else
   protoc_command = 'protoc'
 end
 
-directory "tmp"
+tmp_protoc_out = "tmp/protoc-out"
+
+directory tmp_protoc_out
 
 genproto_output = []
 
@@ -57,14 +59,14 @@ unless ENV['IN_DOCKER'] == 'true' or ENV['BAZEL'] == 'true'
   well_known_protos.each do |proto_file|
     input_file = File.join("../src/", proto_file)
     output_basename = File.basename(proto_file).sub(/\.proto$/, "_pb.rb")
-    tmp_output_file = File.join("tmp/", File.dirname(proto_file), output_basename)
+    tmp_output_file = File.join(tmp_protoc_out, File.dirname(proto_file), output_basename)
     # Generated _pb.rb for files in subdirectories of google/protobuf
     # (eg: ../src/google/protobuf/compiler/plugin.proto) should all still end up
     # in lib/google/protobuf.
     output_file = File.join("lib/google/protobuf", output_basename)
     genproto_output << output_file
-    file output_file => [input_file, "tmp"] do |file_task|
-      sh "#{protoc_command} -I../src --ruby_out=tmp #{input_file}"
+    file output_file => [input_file, tmp_protoc_out] do |file_task|
+      sh "#{protoc_command} -I../src --ruby_out=#{tmp_protoc_out} #{input_file}"
       FileUtils.cp tmp_output_file, output_file
     end
   end

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -180,6 +180,16 @@ task :clean do
 end
 
 Gem::PackageTask.new(spec) do |pkg|
+  # When packaging the gem via `rake gem`, we only want to define
+  # "ext/google/protobuf_c/extconf.rb" as the extension to build the C
+  # extension.
+  pkg.gem_spec.extensions = pkg.gem_spec.extensions.map do |extension|
+    extension == "Rakefile" ? "ext/google/protobuf_c/extconf.rb" : extension
+  end
+
+  pkg.gem_spec.files = pkg.gem_spec.files.reject { |f| f == "Rakefile" }
+
+  pkg.package_files.exclude("Rakefile")
 end
 
 # Skip build/genproto in Bazel builds, where we expect this to

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -18,6 +18,7 @@ well_known_protos = %w[
   google/protobuf/timestamp.proto
   google/protobuf/type.proto
   google/protobuf/wrappers.proto
+  google/protobuf/compiler/plugin.proto
 ]
 
 test_protos = %w[
@@ -38,12 +39,6 @@ test_protos = %w[
   tests/utf8.proto
 ]
 
-# These are omitted for now because we don't support proto2.
-proto2_protos = %w[
-  google/protobuf/descriptor.proto
-  google/protobuf/compiler/plugin.proto
-]
-
 if !ENV['PROTOC'].nil?
   protoc_command = ENV['PROTOC']
 elsif system('../bazel-bin/protoc --version')
@@ -52,17 +47,25 @@ else
   protoc_command = 'protoc'
 end
 
+directory "tmp"
+
 genproto_output = []
 
 # We won't have access to .. from within docker, but the proto files
 # will be there, thanks to the :genproto rule dependency for gem:native.
 unless ENV['IN_DOCKER'] == 'true' or ENV['BAZEL'] == 'true'
   well_known_protos.each do |proto_file|
-    input_file = "../src/" + proto_file
-    output_file = "lib/" + proto_file.sub(/\.proto$/, "_pb.rb")
+    input_file = File.join("../src/", proto_file)
+    output_basename = File.basename(proto_file).sub(/\.proto$/, "_pb.rb")
+    tmp_output_file = File.join("tmp/", File.dirname(proto_file), output_basename)
+    # Generated _pb.rb for files in subdirectories of google/protobuf
+    # (eg: ../src/google/protobuf/compiler/plugin.proto) should all still end up
+    # in lib/google/protobuf.
+    output_file = File.join("lib/google/protobuf", output_basename)
     genproto_output << output_file
-    file output_file => input_file do |file_task|
-      sh "#{protoc_command} -I../src --ruby_out=lib #{input_file}"
+    file output_file => [input_file, "tmp"] do |file_task|
+      sh "#{protoc_command} -I../src --ruby_out=tmp #{input_file}"
+      FileUtils.cp tmp_output_file, output_file
     end
   end
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -189,7 +189,7 @@ Gem::PackageTask.new(spec) do |pkg|
     extension == "Rakefile" ? "ext/google/protobuf_c/extconf.rb" : extension
   end
 
-  pkg.gem_spec.files = pkg.gem_spec.files.reject { |f| f == "Rakefile" }
+  pkg.gem_spec.files.reject! { |f| f == "Rakefile" }
 
   pkg.package_files.exclude("Rakefile")
 end

--- a/ruby/google-protobuf.gemspec
+++ b/ruby/google-protobuf.gemspec
@@ -25,9 +25,17 @@ Gem::Specification.new do |s|
     s.files     += Dir.glob('ext/**/*').reject do |file|
       File.basename(file) =~ /^(BUILD\.bazel)$/
     end
-    s.extensions = %w[
-      ext/google/protobuf_c/extconf.rb
-      ext/google/protobuf_c/Rakefile
+
+    # When installing this gem from git via bundler
+    # (ie: 'gem "google-protobuf", git: "https://.../protobuf.git"' in your
+    # Gemfile), Rakefile is necessary so the prerequisite tasks run to copy
+    # third party C libraries and generate well known protobufs.  When building
+    # the gem via `rake gem`, these steps will have already occurred, and so we
+    # replace the `Rakefile` extension with `ext/google/protobuf_c/extconf.rb`.
+    # See the `Gem::PackageTask.new` declaration in `Rakefile` for more details.
+    s.extensions = [
+      File.exist?("Rakefile") ? "Rakefile" : "ext/google/protobuf_c/extconf.rb",
+      "ext/google/protobuf_c/Rakefile"
     ]
   end
   s.required_ruby_version = '>= 3.1'


### PR DESCRIPTION
## Overview

Currently, `google-protobuf` can't be installed via `git` in a `Gemfile`.  ie, the following doesn't work:

```ruby
# Gemfile
gem "google-protobuf", git: "https://github.com/Shopify/protobuf.gif", branch: "master", submodules: true
```
Trying to `bundle install` with this ☝️ in your `Gemfile` will result in the following error:

```
Fetching https://github.com/Shopify/protobuf.git
Fetching gem metadata from https://pkgs.shopify.io/basic/gems/ruby/...
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Resolving dependencies...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/dave/.gem/ruby/3.4.1/bundler/gems/protobuf-8b63023562e0/ruby/ext/google/protobuf_c
/opt/rubies/3.4.1/bin/ruby extconf.rb
creating Makefile

current directory: /Users/dave/.gem/ruby/3.4.1/bundler/gems/protobuf-8b63023562e0/ruby/ext/google/protobuf_c
make DESTDIR\= sitearchdir\=./.gem.20250331-44786-nchu9i sitelibdir\=./.gem.20250331-44786-nchu9i clean

current directory: /Users/dave/.gem/ruby/3.4.1/bundler/gems/protobuf-8b63023562e0/ruby/ext/google/protobuf_c
make DESTDIR\= sitearchdir\=./.gem.20250331-44786-nchu9i sitelibdir\=./.gem.20250331-44786-nchu9i
compiling protobuf.c
In file included from protobuf.c:8:
In file included from ./protobuf.h:23:
In file included from ./defs.h:12:
./ruby-upb.h:1018:18: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
 1018 |   *overrun = ptr - e->end;
      |            ~ ~~~~^~~~~~~~
./ruby-upb.h:1151:64: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
 1151 |          upb_EpsCopyInputStream_CheckDataSizeAvailable(e, ptr, size);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~         ^~~~
./ruby-upb.h:1222:65: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
 1222 |     if (!upb_EpsCopyInputStream_CheckDataSizeAvailable(e, *ptr, size)) {
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~          ^~~~
./ruby-upb.h:1228:66: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
 1228 |     const char* ret = upb_EpsCopyInputStream_Copy(e, *ptr, data, size);
      |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~                ^~~~
./ruby-upb.h:1314:27: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
 1314 |   e->limit = e->limit_ptr - e->end;
      |            ~ ~~~~~~~~~~~~~^~~~~~~~
./ruby-upb.h:1390:19: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
 1390 |     return a.size - b.size;
      |     ~~~~~~ ~~~~~~~^~~~~~~~
./ruby-upb.h:4358:19: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
 4357 |     array = UPB_PRIVATE(_upb_Array_New)(
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 4358 |         arena, 4, UPB_PRIVATE(_upb_MiniTableField_ElemSizeLg2)(f));
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./ruby-upb.h:275:24: note: expanded from macro 'UPB_PRIVATE'
  275 | #define UPB_PRIVATE(x) x##_dont_copy_me__upb_internal_use_only
      |                        ^
<scratch space>:19:1: note: expanded from here
   19 | _upb_MiniTableField_ElemSizeLg2_dont_copy_me__upb_internal_use_only
      | ^
In file included from protobuf.c:8:
In file included from ./protobuf.h:23:
In file included from ./defs.h:12:
./ruby-upb.h:14850:10: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
 14850 |   *tag = val;
       |        ~ ^~~
./ruby-upb.h:14886:11: warning: implicit conversion loses integer precision: 'uint64_t' (aka 'unsigned long long') to 'int' [-Wshorten-64-to-32]
 14886 |   *size = size64;
       |         ~ ^~~~~~
./ruby-upb.h:15299:10: fatal error: 'utf8_range.h' file not found
 15299 | #include "utf8_range.h"
       |          ^~~~~~~~~~~~~~
9 warnings and 1 error generated.
make: *** [protobuf.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/dave/.gem/ruby/3.4.1/bundler/gems/protobuf-8b63023562e0/ruby for inspection.
Results logged to /Users/dave/.gem/ruby/3.4.1/bundler/gems/extensions/arm64-darwin-23/3.4.0/protobuf-8b63023562e0-ruby/gem_make.out

  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:126:in 'Gem::Ext::Builder.run'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:52:in 'block in Gem::Ext::Builder.make'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:44:in 'Array#each'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:44:in 'Gem::Ext::Builder.make'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/ext_conf_builder.rb:44:in 'Gem::Ext::ExtConfBuilder.build'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:195:in 'Gem::Ext::Builder#build_extension'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:229:in 'block in Gem::Ext::Builder#build_extensions'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:226:in 'Array#each'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/ext/builder.rb:226:in 'Gem::Ext::Builder#build_extensions'
  /opt/rubies/3.4.1/lib/ruby/3.4.0/rubygems/installer.rb:844:in 'Gem::Installer#build_extensions'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/rubygems_gem_installer.rb:111:in 'Bundler::RubyGemsGemInstaller#build_extensions'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/source/path/installer.rb:28:in 'Bundler::Source::Path::Installer#post_install'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/source/path.rb:234:in 'Bundler::Source::Path#generate_bin'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/source/git.rb:212:in 'Bundler::Source::Git#install'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/installer/gem_installer.rb:55:in 'Bundler::GemInstaller#install'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/installer/gem_installer.rb:17:in 'Bundler::GemInstaller#install_from_spec'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/installer/parallel_installer.rb:133:in 'Bundler::ParallelInstaller#do_install'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/installer/parallel_installer.rb:124:in 'block in Bundler::ParallelInstaller#worker_pool'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/worker.rb:62:in 'Bundler::Worker#apply_func'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/worker.rb:57:in 'block in Bundler::Worker#process_queue'
  <internal:kernel>:168:in 'Kernel#loop'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/worker.rb:54:in 'Bundler::Worker#process_queue'
  /Users/dave/.gem/ruby/3.4.1/gems/bundler-2.6.3/lib/bundler/worker.rb:90:in 'block (2 levels) in Bundler::Worker#create_threads'

An error occurred while installing google-protobuf (4.31.0), and Bundler cannot continue.

In Gemfile:
  grpc was resolved to 1.71.0, which depends on
    googleapis-common-protos-types was resolved to 1.19.0, which depends on
      google-protobuf
```

The changes in this PR fix this particular problem.  There is also a small change to `ruby/BUILD.bazel` that fixes `bazel build //ruby:release` on macOS, but I'm happy to simplify things by removing that commit if we want to tackle that separately.  For the purposes of this PR it was handy to be able to easily verify these changes didn't break the existing gem build process.  Additionally, this also tweaks the `Rakefile` so the gem will contain one well-defined compiled proto file, `lib/google/protobuf/plugin_pb.rb`, which was also absent due to the way the `bazel` build was configured.

## Description of Changes

The problem with the `gemspec` and `Rakefile` as they're currently configured is the `protobuf_c` C binding can't be built without first running the `:copy_well_known` rake task, which copies a `utf8_range` library over from `../third_party`, which `protobuf_c` depends on.  The `gemspec` provides an `extensions` array where developers can define one or more native extensions as part of the gem install process.  Fortunately, `extensions` entries can either be an `extconf.rb` file (which generates a `Makefile` for a C build), or a `Rakefile`.  In the case of the latter, the `:build` rake task will be run as part of the gem install process.  The `Rakefile` in this project is fairly complicated and relies on files outside of the `ruby/` subdirectory to run properly, so the ideal case is we use the `Rakefile` to compile the native extension in the case of installing the gem via git, and continue to just use the `ext/google/protobuf_c/extconf.rb` configuration file for the case of installing the bundled `.gem` package.  For `gem build google-protobuf-*.gem` to continue to work, which is what `bazel build //ruby:release` invokes, the `gemspec` needs to return `ext/google/protobuf_c/extconf.rb` as the first `extensions` entry, which is taken care of here:

https://github.com/Shopify/protobuf/pull/12/files#diff-b62c3d0cbc3851b5b830f3102dd161f6a74ae1c72fb5a0fc27c18f4e296e650bR37

However, this change would also cause `rake gem` to include the `Rakefile` in the `.gem` package and configure `Rakefile` as the extension in the gem `metadata`, which we don't want.  To get around that problem, we have to pass a simple block to `Rake::GemTask.new` to tweak the configuration before the relevant rake tasks are generated.  Note that this is a built-in feature of rake  + `Gem::PackageTask` and is not an uncommon pattern.

https://github.com/Shopify/protobuf/pull/12/files#diff-2f4efc2778c5f85411f077bc711c6701f1d67786776948a38a042e1b55d27679R182-R193

I think the comments I left make this pretty clear but I'm happy to revisit that if we need to.

The missing `lib/protobuf/plugin_pb.rb` file was a matter of updating the `well_known_protos` array:

https://github.com/Shopify/protobuf/pull/12/files#diff-2f4efc2778c5f85411f077bc711c6701f1d67786776948a38a042e1b55d27679R9-R22

Although, as-is, the existing `:genproto` task would have placed this file in `lib/google/protobuf/compiler/plugin_pb.rb`, since the file appears in `../src/google/protobuf/compiler/plugin.proto`.  In the currently published gem, this file is just in the `lib/google/protobuf` directory (no `compiler/` at the end of the path).  To get around that I also tweaked the `:genproto` task:
 
https://github.com/Shopify/protobuf/pull/12/files#diff-2f4efc2778c5f85411f077bc711c6701f1d67786776948a38a042e1b55d27679R57-R68

Finally, I made a small tweak to `ruby/BUILD.bazel` just to make `bazel build //ruby:release` run on macOS.  Again, this is is a separate commit and it's easy enough for me to remove it.

https://github.com/Shopify/protobuf/pull/12/files#diff-c395e34350d010fae10f265af258138c0446a703912ca14e8d271bf21128dfb6

The issue there is `cp --parents` is a *nix-only feature and doesn't appear in BSD's version of `cp`.

## Testing

I tested this by trying the following:

### packaged gem
(From the project root, not the `ruby/` directory)
0) `gem uninstall google-protobuf` and confirm I was working from a clean slate
1) `bazel build //ruby:release`
2) `gem install bazel-out/darwin_arm64-fastbuild/bin/ruby/google-protobuf-4.31.0.gem`
3) Use `irb` to `require "google-protobuf"` and confirm I could require `google/protobuf/plugin_pb.rb`

### Installing via git source
1) From another project I added `gem "google-protobuf", git: "https://github.com/Shopify/protobuf.gif", branch: "master", submodules: true` to a `Gemfile`
2) `bundle install` (from the other project)
3) Ran `rake` successfully (in the other project)
4) Confirmed the installed gem who's path I got from `bundle show google-protobuf` contained the `protobuf_c.bundle` as well as the expected `lib/google/protobuf/*_pb.rb`

### `rake gem`
(From the `ruby/` subdirectory)
1) Followed the instructions from `ruby/README.md`:
  a) `rake`
  b) `rake clobber_package gem`
2) Inspected the contents of the resulting gem and confirmed all expected `ext/google/protobuf_c/third_party/utf8_range` files as well as `lib/google/protobuf/*_pb.rb` were present