### PR TITLE
[ruby] Optionally link ASAN with --enable-asan

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -88,13 +88,32 @@ Then build the Gem:
     $ rake clobber_package gem
     $ gem install `ls pkg/google-protobuf-*.gem`
 
+Debugging protobuf_c
+--------------------
+
+### Enabling debug symbols
+
 If you intend to debug the protobuf_c Ruby bindings with `gdb`, you can also
 build a version with debug symbols enabled by setting the `PROTOBUF_CONFIG`
 enviroment variable when you build the native extension:
 
-```
-$ PROTOBUF_CONFIG=dbg rake
-```
+
+    $ PROTOBUF_CONFIG=dbg rake
+
+### Building with ASAN
+
+`PROTOBUF_CONFIG` can also take the value `asan`. In addition to enabling debug
+options this will enable and link against AddressSanitizer in order to debug
+memory errors.
+
+    $ PROTOBUF_CONFIG=asan rake
+
+Because Ruby native extensions are loaded when required using `dlopen`,
+extensions compiled with ASAN will attempt to load the sanitizer too late (after
+`libc`). Therefore to successfully use ASAN you'll need to insert it using the
+environment variable `LD_PRELOAD` (`DYLD_INSERT_LIBRARIES` on macOS).
+
+### Running tests
 
 To run the specs:
 

--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -18,9 +18,23 @@ if ENV["LD"]
   RbConfig::CONFIG["LD"] = RbConfig::MAKEFILE_CONFIG["LD"] = ENV["LD"]
 end
 
-debug_enabled = ENV["PROTOBUF_CONFIG"] == "dbg"
+config = ENV["PROTOBUF_CONFIG"]
+build_configs = {
+  "dbg"  => {
+    :cflags => "-O0 -fno-omit-frame-pointer -fvisibility=default -g"
+  },
+  "asan" => {
+    :cflags => "-O0 -fno-omit-frame-pointer -fvisibility=default -g -fsanitize=address",
+    :ldflags => "-fsanitize=address"
+  }
+}
 
-additional_c_flags = debug_enabled ? "-O0 -fno-omit-frame-pointer -fvisibility=default -g" : "-O3 -DNDEBUG -fvisibility=hidden"
+if build_configs[config]
+  additional_c_flags = build_configs[config][:cflags]
+  $LDFLAGS += " #{build_configs[config][:ldflags]}" if build_configs[config][:ldflags]
+else
+  additional_c_flags = "-O3 -DNDEBUG -fvisibility=hidden"
+end
 
 if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/ || RUBY_PLATFORM =~ /freebsd/
   $CFLAGS += " -std=gnu99 -Wall -Wsign-compare -Wno-declaration-after-statement #{additional_c_flags}"

--- a/ruby/ext/google/protobuf_c/extconf.rb
+++ b/ruby/ext/google/protobuf_c/extconf.rb
@@ -29,11 +29,25 @@ build_configs = {
   }
 }
 
+default_cflags = "-O3 -DNDEBUG -fvisibility=hidden"
+
+unknown_config = <<~UNKNOWN_CONFIG
+  ERROR: Unknown PROTOBUF_CONFIG value: #{config}
+
+  Valid options are: #{build_configs.keys.join(", ")}
+UNKNOWN_CONFIG
+
 if build_configs[config]
   additional_c_flags = build_configs[config][:cflags]
   $LDFLAGS += " #{build_configs[config][:ldflags]}" if build_configs[config][:ldflags]
+elsif config.nil?
+  additional_c_flags = default_cflags
+elsif config.empty?
+  warn "PROTOBUF_CONFIG has been set to an empty string, using default CFLAGS: #{default_cflags}"
+  additional_c_flags = default_cflags
 else
-  additional_c_flags = "-O3 -DNDEBUG -fvisibility=hidden"
+  warn unknown_config
+  exit 1
 end
 
 if RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/ || RUBY_PLATFORM =~ /freebsd/


### PR DESCRIPTION
Quick patch to conditionally enable asan on the Ruby extension builds. 

Opening as a PR here for review, because I'm entirely unconfident I haven't just missed something in Bazel and this is already a thing.