### PR TITLE
Fix warnings in Ruby tests

### DIFF
--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/ruby
+# frozen_string_literal: false
 
 # basic_test_pb.rb is in the same directory as this test.
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))

--- a/ruby/tests/basic.rb
+++ b/ruby/tests/basic.rb
@@ -12,9 +12,6 @@ require 'json'
 require 'test/unit'
 
 module BasicTest
-  TestMessage = BasicTest::TestMessage
-  Outer = BasicTest::Outer
-
   class MessageContainerTest < Test::Unit::TestCase
     # Required by CommonTests module to resolve proto3 proto classes used in tests.
     def proto_module

--- a/ruby/tests/basic_proto2.rb
+++ b/ruby/tests/basic_proto2.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/ruby
+# frozen_string_literal: false
 
 # basic_test_pb.rb is in the same directory as this test.
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__)))

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require 'google/protobuf/wrappers_pb.rb'
 
 # Defines tests which are common between proto2 and proto3 syntax.

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -28,9 +28,9 @@ module CommonTests
   def test_setters
     m = proto_module::TestMessage.new
     m.optional_int32 = -42
-    assert_equal -42, m.optional_int32
+    assert_equal(-42, m.optional_int32)
     m.optional_int64 = -0x1_0000_0000
-    assert_equal -0x1_0000_0000, m.optional_int64
+    assert_equal(-0x1_0000_0000, m.optional_int64)
     m.optional_uint32 = 0x9000_0000
     assert_equal 0x9000_0000, m.optional_uint32
     m.optional_uint64 = 0x9000_0000_0000_0000
@@ -62,7 +62,7 @@ module CommonTests
                                       :optional_msg => proto_module::TestMessage2.new,
                                       :optional_enum => :C,
                                       :repeated_string => ["hello", "there", "world"])
-    assert_equal -42, m.optional_int32
+    assert_equal(-42, m.optional_int32)
     assert_instance_of proto_module::TestMessage2, m.optional_msg
     assert_equal 3, m.repeated_string.length
     assert_equal :C, m.optional_enum

--- a/ruby/tests/common_tests.rb
+++ b/ruby/tests/common_tests.rb
@@ -1654,16 +1654,9 @@ module CommonTests
     assert_raises(Google::Protobuf::TypeError) { m.timestamp = '4' }
     assert_raises(Google::Protobuf::TypeError) { m.timestamp = proto_module::TimeMessage.new }
 
-    def test_time(year, month, day)
-      str = ("\"%04d-%02d-%02dT00:00:00.000+00:00\"" % [year, month, day])
-      t = Google::Protobuf::Timestamp.decode_json(str)
-      time = Time.new(year, month, day, 0, 0, 0, "+00:00")
-      assert_equal t.seconds, time.to_i
-    end
-
     (1970..2010).each do |year|
-      test_time(year, 2, 28)
-      test_time(year, 3, 01)
+      assert_time_equal(year, 2, 28)
+      assert_time_equal(year, 3, 01)
     end
   end
 
@@ -1937,5 +1930,14 @@ module CommonTests
     assert_respond_to msg, :double_as_value
     assert_equal 42, msg.double_as_value
     assert_equal Google::Protobuf::DoubleValue.new(value: 42), msg.double
+  end
+
+  private
+
+  def assert_time_equal(year, month, day)
+    str = ("\"%04d-%02d-%02dT00:00:00.000+00:00\"" % [year, month, day])
+    t = Google::Protobuf::Timestamp.decode_json(str)
+    time = Time.new(year, month, day, 0, 0, 0, "+00:00")
+    assert_equal t.seconds, time.to_i
   end
 end

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -8,30 +8,6 @@ require 'generated_code_pb'
 require 'google/protobuf/well_known_types'
 require 'test/unit'
 
-module CaptureWarnings
-  @@warnings = nil
-
-  module_function
-
-  def warn(message, category: nil, **kwargs)
-    if @@warnings
-      @@warnings << message
-    else
-      super
-    end
-  end
-
-  def capture
-    @@warnings = []
-    yield
-    @@warnings
-  ensure
-    @@warnings = nil
-  end
-end
-
-Warning.extend CaptureWarnings
-
 def hex2bin(s)
   s.scan(/../).map { |x| x.hex.chr }.join
 end

--- a/ruby/tests/encode_decode_test.rb
+++ b/ruby/tests/encode_decode_test.rb
@@ -39,13 +39,13 @@ end
 class NonConformantNumericsTest < Test::Unit::TestCase
   def test_empty_json_numerics
     assert_raises Google::Protobuf::ParseError do
-      msg = ::BasicTestProto2::TestMessage.decode_json('{"optionalInt32":""}')
+      ::BasicTestProto2::TestMessage.decode_json('{"optionalInt32":""}')
     end
   end
 
   def test_trailing_non_numeric_characters
     assert_raises Google::Protobuf::ParseError do
-      msg = ::BasicTestProto2::TestMessage.decode_json('{"optionalDouble":"123abc"}')
+      ::BasicTestProto2::TestMessage.decode_json('{"optionalDouble":"123abc"}')
     end
   end
 end

--- a/ruby/tests/repeated_field_test.rb
+++ b/ruby/tests/repeated_field_test.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/ruby
+# frozen_string_literal: false
 
 require 'google/protobuf'
 require 'repeated_field_test_pb'

--- a/ruby/tests/utf8.rb
+++ b/ruby/tests/utf8.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/ruby
+# frozen_string_literal: false
 
 require 'google/protobuf'
 require 'utf8_pb'

--- a/ruby/tests/utf8.rb
+++ b/ruby/tests/utf8.rb
@@ -5,30 +5,6 @@ require 'google/protobuf'
 require 'utf8_pb'
 require 'test/unit'
 
-module CaptureWarnings
-  @@warnings = nil
-
-  module_function
-
-  def warn(message, category: nil, **kwargs)
-    if @@warnings
-      @@warnings << message
-    else
-      super
-    end
-  end
-
-  def capture
-    @@warnings = []
-    yield
-    @@warnings
-  ensure
-    @@warnings = nil
-  end
-end
-
-Warning.extend CaptureWarnings
-
 module Utf8Test
   def test_scalar
     msg = Utf8TestProtos::TestUtf8.new

--- a/ruby/tests/utf8.rb
+++ b/ruby/tests/utf8.rb
@@ -98,7 +98,7 @@ end
 # but contain invalid UTF-8.
 #
 # This case will raise Encoding::UndefinedConversionError.
-class MarkedNonUtf8Test < Test::Unit::TestCase
+class MarkedNonUtf8InvalidUtf8Test < Test::Unit::TestCase
   def assert_bad_utf8
     assert_raises(Encoding::UndefinedConversionError) { yield }
   end
@@ -116,7 +116,7 @@ end
 # but are invalid even in their source encoding.
 #
 # This case will raise Encoding::InvalidByteSequenceError
-class MarkedNonUtf8Test < Test::Unit::TestCase
+class MarkedNonUtf8InvalidSourceTest < Test::Unit::TestCase
   def assert_bad_utf8(&block)
     assert_raises(Encoding::InvalidByteSequenceError, &block)
   end


### PR DESCRIPTION
There are quite a lot of warnings when running the Ruby tests against a recent Ruby. So this PR turns this:

<details><summary>CLI output when running `rake test`</summary>

```
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:30: warning: ambiguous first argument; put parentheses or a space even after `-` operator
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:32: warning: ambiguous first argument; put parentheses or a space even after `-` operator
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:64: warning: ambiguous first argument; put parentheses or a space even after `-` operator
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/basic.rb:14: warning: already initialized constant BasicTest::TestMessage
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/basic_test_pb.rb:24: warning: previous definition of TestMessage was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/basic.rb:15: warning: already initialized constant BasicTest::Outer
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/basic_test_pb.rb:38: warning: previous definition of Outer was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/encode_decode_test.rb:42: warning: assigned but unused variable - msg
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/encode_decode_test.rb:48: warning: assigned but unused variable - msg
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:12: warning: method redefined; discarding old warn
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/encode_decode_test.rb:16: warning: previous definition of warn was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:12: warning: method redefined; discarding old warn
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/encode_decode_test.rb:16: warning: previous definition of warn was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:20: warning: method redefined; discarding old capture
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/encode_decode_test.rb:24: warning: previous definition of capture was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:20: warning: method redefined; discarding old capture
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/encode_decode_test.rb:24: warning: previous definition of capture was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:119: warning: method redefined; discarding old assert_bad_utf8
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:101: warning: previous definition of assert_bad_utf8 was here
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:123: warning: method redefined; discarding old bad_utf8_string
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:105: warning: previous definition of bad_utf8_string was here
Loaded suite /Users/mattvh/.rubies/v3.4.3-debug/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader
Started
O
==================================================================================================================================================================================================================
Omission: FFI implementation requires environment variable PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI to activate. [test_ffi_implementation(BackendTest)]
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/implementation.rb:20:in 'BackendTest#test_ffi_implementation'
==================================================================================================================================================================================================================
O
==================================================================================================================================================================================================================
Omission: FFI implementation requires environment variable PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI to activate. [test_prefer_ffi(BackendTest)]
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/implementation.rb:14:in 'BackendTest#test_prefer_ffi'
==================================================================================================================================================================================================================
|/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:47: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
-/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:191: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:197: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:209: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
|/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/basic.rb:614: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:1656: warning: method redefined; discarding old test_time
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:1656: warning: previous definition of test_time was here
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/basic_proto2.rb:120: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:47: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
//Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:191: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:197: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/common_tests.rb:209: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:88: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
|/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:88: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
//Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:88: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
-/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:88: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:124: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
|/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:124: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
//Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:124: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
-/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/utf8.rb:124: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:271: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:272: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:53: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
|/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:82: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
-/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:120: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:121: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/repeated_field_test.rb:663: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
\No kokoro ruby version found, skipping check
Finished in 10.798327 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
326 tests, 546233 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
30.19 tests/s, 50584.97 assertions/s
```

</details>

Into this:

```
Loaded suite /Users/mattvh/.rubies/v3.4.3-debug/lib/ruby/gems/3.4.0/gems/rake-13.2.1/lib/rake/rake_test_loader
Started
O
==================================================================================================================================================================================================================
Omission: FFI implementation requires environment variable PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI to activate. [test_ffi_implementation(BackendTest)]
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/implementation.rb:20:in 'BackendTest#test_ffi_implementation'
==================================================================================================================================================================================================================
O
==================================================================================================================================================================================================================
Omission: FFI implementation requires environment variable PROTOCOL_BUFFERS_RUBY_IMPLEMENTATION=FFI to activate. [test_prefer_ffi(BackendTest)]
/Users/mattvh/workspaces/protobuf-ruby/folders/protobuf/ruby/tests/implementation.rb:14:in 'BackendTest#test_prefer_ffi'
==================================================================================================================================================================================================================
\No kokoro ruby version found, skipping check
Finished in 10.61726 seconds.
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
330 tests, 562596 assertions, 0 failures, 0 errors, 0 pendings, 2 omissions, 0 notifications
100% passed
```