### PR TITLE
Ruby: Optionally warn when arena chains grow large

### DIFF
--- a/ruby/ext/google/protobuf_c/protobuf.c
+++ b/ruby/ext/google/protobuf_c/protobuf.c
@@ -7,10 +7,24 @@
 
 #include "protobuf.h"
 
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
 #include "defs.h"
 #include "map.h"
 #include "message.h"
 #include "repeated_field.h"
+
+#define BYTES_PER_KB (1024ULL)
+#define BYTES_PER_MB (BYTES_PER_KB * 1024)
+#define BYTES_PER_GB (BYTES_PER_MB * 1024)
+
+#ifndef SIZE_MAX
+#define SIZE_MAX ((size_t)-1)
+#endif
 
 VALUE cParseError;
 VALUE cTypeError;
@@ -207,6 +221,8 @@ upb_Arena *Arena_get(VALUE _arena) {
   return arena->arena;
 }
 
+static size_t arena_fusion_warning_threshold = 0;
+
 void Arena_fuse(VALUE _arena, upb_Arena *other) {
   Arena *arena;
   TypedData_Get_Struct(_arena, Arena, &Arena_type, arena);
@@ -214,6 +230,16 @@ void Arena_fuse(VALUE _arena, upb_Arena *other) {
     rb_raise(rb_eRuntimeError,
              "Unable to fuse arenas. This should never happen since Ruby does "
              "not use initial blocks");
+  }
+
+  if (arena_fusion_warning_threshold > 0) {
+    size_t fused_count;
+    size_t total_size = upb_Arena_SpaceAllocated(arena->arena, &fused_count);
+
+    if (total_size > arena_fusion_warning_threshold) {
+      rb_warning("Large arena growth detected: %zu bytes, %zu arenas.",
+                 total_size, fused_count);
+    }
   }
 }
 
@@ -321,11 +347,72 @@ VALUE Google_Protobuf_deep_copy(VALUE self, VALUE obj) {
 // Initialization/entry point.
 // -----------------------------------------------------------------------------
 
+static size_t parse_size_with_unit(const char* str) {
+  if (!str || !*str) return 0;
+
+  char* endptr;
+  errno = 0;
+  unsigned long long value = strtoull(str, &endptr, 10);
+
+  if (errno == ERANGE || value > SIZE_MAX) {
+    rb_warning("Arena fusion threshold value overflow: %s", str);
+    return BYTES_PER_GB;
+  }
+
+  if (errno != 0 || endptr == str) {
+    rb_warning("Invalid arena fusion threshold value: %s", str);
+    return BYTES_PER_GB;
+  }
+
+  while (*endptr == ' ') endptr++;
+
+  if (*endptr != '\0') {
+    if (strcasecmp(endptr, "KB") == 0) {
+      if (value > SIZE_MAX / BYTES_PER_KB) {
+        rb_warning("Arena fusion threshold overflow with KB unit: %s", str);
+        return BYTES_PER_GB;
+      }
+      value *= BYTES_PER_KB;
+    } else if (strcasecmp(endptr, "MB") == 0) {
+      if (value > SIZE_MAX / BYTES_PER_MB) {
+        rb_warning("Arena fusion threshold overflow with MB unit: %s", str);
+        return BYTES_PER_GB;
+      }
+      value *= BYTES_PER_MB;
+    } else if (strcasecmp(endptr, "GB") == 0) {
+      if (value > SIZE_MAX / BYTES_PER_GB) {
+        rb_warning("Arena fusion threshold overflow with GB unit: %s", str);
+        return BYTES_PER_GB;
+      }
+      value *= BYTES_PER_GB;
+    }
+  }
+
+  return (size_t)value;
+}
+
+static void initialize_arena_fusion_threshold(void) {
+  const char* threshold_env = getenv("PROTOBUF_ARENA_FUSION_WARNING_THRESHOLD");
+
+  if (threshold_env) {
+    arena_fusion_warning_threshold = parse_size_with_unit(threshold_env);
+  } else {
+    arena_fusion_warning_threshold = BYTES_PER_GB;
+  }
+
+  if (ruby_verbose && arena_fusion_warning_threshold > 0) {
+    rb_warning("Protobuf arena fusion warning threshold set to %zu bytes",
+               arena_fusion_warning_threshold);
+  }
+}
+
 // This must be named "Init_protobuf_c" because the Ruby module is named
 // "protobuf_c" -- the VM looks for this symbol in our .so.
 __attribute__((visibility("default"))) void Init_protobuf_c() {
   VALUE google = rb_define_module("Google");
   VALUE protobuf = rb_define_module_under(google, "Protobuf");
+
+  initialize_arena_fusion_threshold();
 
   ObjectCache_Init(protobuf);
   Arena_register(protobuf);


### PR DESCRIPTION
This PR implements an optional warning, enabled when Ruby is run with -W2 verbose mode, that warns when an arena fusion occurs that causes an arena list to grow beyond a certain user defined size defined by PROTOBUF_ARENA_WARNING_THRESHOLD.

The following warning will be emitted when a fusion list crosses the threshold

    warning: Large arena growth detected: 373072 bytes, 1001 arenas.

This is an attempt to mitigate problems arising from fusing arenas attached to objects with mismatched lifetimes as seen in the issues below.

- https://github.com/protocolbuffers/protobuf/issues/19498 
- https://github.com/protocolbuffers/protobuf/issues/10106

Ideally we'd detect when an arena was being fused to an existing arena list with a longer lifetime, but this isn't possible with the information we have about the Ruby object. So this felt like the simplest, least intrusive alternative.

We're hoping that this will be useful for sense-checking protobuf client code in CI, or for assessing the cause for memory issues we see in production.

Given the following test script

```
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gemspec path: __dir__
  gem 'bigdecimal'
end

require_relative 'tests/basic_test_proto2_pb'

msg = BasicTestProto2::TestMessage.new(
  optional_string: "x" * 10_000,  # 10KB
  optional_bytes: ("y" * 10_000).b # 10KB
)

1000.times do |i|
  msg2 = BasicTestProto2::TestMessage2.new(foo: i)
  msg.optional_msg = msg2  # This causes arena fusion

  msg2 = nil
end
```

This will cause every msg and msg2 to be fused together, but none of the resulting memory will ever be able to be GC'd because all arenas are linked to the arena backing the msg, which has a static lifetime. This will cause unbounded memory growth.

The advised solution to this problem is to use `deep_copy` to copy msg2 before assigning it - which will allow the original msg2 to be reclaimed.

But this issue is reasonably hard to identify in non-trivial applications, so the hope is that we'd be able to enable warnings as a debug step and determine how large our arena chains are getting.